### PR TITLE
fix: evitar startsWith en variables indefinidas

### DIFF
--- a/src/services/supabase/client.ts
+++ b/src/services/supabase/client.ts
@@ -1,13 +1,26 @@
 import { createBrowserClient } from "@supabase/ssr";
 
 export function createClient() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
   // Validar que las URLs son válidas para desarrollo
-  if (supabaseUrl === 'your_supabase_project_url' || !supabaseUrl.startsWith('http')) {
-    console.warn('⚠️  Usando variables de entorno de desarrollo. Configura .env.local con credenciales reales de Supabase.');
+  if (
+    !supabaseUrl ||
+    supabaseUrl === 'your_supabase_project_url' ||
+    !supabaseUrl.startsWith('http')
+  ) {
+    console.warn(
+      '⚠️  Usando variables de entorno de desarrollo. Configura .env.local con credenciales reales de Supabase.'
+    );
     // Retornar un cliente mock para desarrollo
+    return null as any;
+  }
+
+  if (!supabaseKey) {
+    console.warn(
+      '⚠️  Falta NEXT_PUBLIC_SUPABASE_ANON_KEY. Configura .env.local con credenciales reales de Supabase.'
+    );
     return null as any;
   }
 

--- a/src/services/supabase/server.ts
+++ b/src/services/supabase/server.ts
@@ -3,14 +3,27 @@ import { cookies } from 'next/headers'
 
 export async function createClient() {
   const cookieStore = await cookies()
-  
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
   // Validar que las URLs son válidas para desarrollo
-  if (supabaseUrl === 'your_supabase_project_url' || !supabaseUrl.startsWith('http')) {
-    console.warn('⚠️  Usando variables de entorno de desarrollo. Configura .env.local con credenciales reales de Supabase.');
+  if (
+    !supabaseUrl ||
+    supabaseUrl === 'your_supabase_project_url' ||
+    !supabaseUrl.startsWith('http')
+  ) {
+    console.warn(
+      '⚠️  Usando variables de entorno de desarrollo. Configura .env.local con credenciales reales de Supabase.'
+    );
     // Retornar un cliente mock para desarrollo
+    return null as any;
+  }
+
+  if (!supabaseKey) {
+    console.warn(
+      '⚠️  Falta NEXT_PUBLIC_SUPABASE_ANON_KEY. Configura .env.local con credenciales reales de Supabase.'
+    );
     return null as any;
   }
 


### PR DESCRIPTION
## Resumen
- Maneja credenciales de Supabase ausentes para evitar llamadas `startsWith` sobre variables indefinidas.

## Pruebas
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae82081d048330b619df76a6783345