### PR TITLE
Validar variables de entorno antes de crear cliente de Supabase

### DIFF
--- a/src/services/supabase/middleware.ts
+++ b/src/services/supabase/middleware.ts
@@ -2,13 +2,30 @@ import { createServerClient } from '@supabase/ssr'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function updateSession(request: NextRequest) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (
+    !supabaseUrl ||
+    supabaseUrl === 'your_supabase_project_url' ||
+    !supabaseUrl.startsWith('http')
+  ) {
+    console.warn('Missing or invalid NEXT_PUBLIC_SUPABASE_URL')
+    return NextResponse.next({ request })
+  }
+
+  if (!supabaseKey) {
+    console.warn('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY')
+    return NextResponse.next({ request })
+  }
+
   let supabaseResponse = NextResponse.next({
     request,
   })
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseKey,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## Resumen
- Verifica presencia y formato de `NEXT_PUBLIC_SUPABASE_URL` y `NEXT_PUBLIC_SUPABASE_ANON_KEY` antes de instanciar el cliente de Supabase.
- Evita la creación del cliente y avisa por consola cuando faltan variables de entorno.
- Utiliza las variables validadas al crear el cliente con `createServerClient`.

## Pruebas
- `npm run lint`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae8dbd96bc83309d64ebc08e141a46