### PR TITLE
fix: valida URL de Supabase y asegura hook de auth en cliente

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -34,7 +34,7 @@ function NavigationLink({ href, children, onClick, className = '' }: NavigationL
   const baseClasses = "text-gray-700 hover:text-primary-600 transition-colors font-medium"
   
   const handleClick = (e: React.MouseEvent) => {
-    if (href.startsWith('#')) {
+    if (href && href.startsWith('#')) {
       e.preventDefault()
       const targetId = href.substring(1)
       const targetElement = document.getElementById(targetId)

--- a/src/features/auth/components/AuthProvider.tsx
+++ b/src/features/auth/components/AuthProvider.tsx
@@ -23,7 +23,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(false) // ✅ Iniciar en false
   const [profile, setProfile] = useState(null)
   const [mounted, setMounted] = useState(false) // ✅ Control de hidratación
-  const supabase = createClient()
+  const supabase = typeof window !== 'undefined' ? createClient() : null
 
   const refreshProfile = async () => {
     if (user && supabase) {

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { useContext } from 'react'
 import { AuthContext } from '../components/AuthProvider'
 

--- a/src/services/supabase/client.ts
+++ b/src/services/supabase/client.ts
@@ -4,9 +4,16 @@ export function createClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-  // Validar que las URLs son válidas para desarrollo
+  // Validar que la URL esté definida antes de usar startsWith
+  if (!supabaseUrl) {
+    console.warn(
+      '⚠️  Falta NEXT_PUBLIC_SUPABASE_URL. Configura .env.local con credenciales reales de Supabase.'
+    );
+    return null as any;
+  }
+
+  // Validar que las URLs sean correctas para desarrollo
   if (
-    !supabaseUrl ||
     supabaseUrl === 'your_supabase_project_url' ||
     !supabaseUrl.startsWith('http')
   ) {

--- a/src/services/supabase/middleware.ts
+++ b/src/services/supabase/middleware.ts
@@ -5,8 +5,12 @@ export async function updateSession(request: NextRequest) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
+  if (!supabaseUrl) {
+    console.warn('Missing NEXT_PUBLIC_SUPABASE_URL')
+    return NextResponse.next({ request })
+  }
+
   if (
-    !supabaseUrl ||
     supabaseUrl === 'your_supabase_project_url' ||
     !supabaseUrl.startsWith('http')
   ) {

--- a/src/services/supabase/server.ts
+++ b/src/services/supabase/server.ts
@@ -7,9 +7,16 @@ export async function createClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-  // Validar que las URLs son válidas para desarrollo
+  // Validar que la URL esté definida antes de usar startsWith
+  if (!supabaseUrl) {
+    console.warn(
+      '⚠️  Falta NEXT_PUBLIC_SUPABASE_URL. Configura .env.local con credenciales reales de Supabase.'
+    );
+    return null as any;
+  }
+
+  // Validar que las URLs sean correctas para desarrollo
   if (
-    !supabaseUrl ||
     supabaseUrl === 'your_supabase_project_url' ||
     !supabaseUrl.startsWith('http')
   ) {


### PR DESCRIPTION
## Resumen
- Valida la existencia de `NEXT_PUBLIC_SUPABASE_URL` antes de usar `startsWith`
- Ajusta `AuthProvider` y `useAuth` para ejecutarse solo en el cliente
- Evita fallos al usar enlaces con `startsWith`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aef2ceb1c883308bb824414e3b4821