### PR TITLE
feat(seo): add SEO tooling and performance optimizations

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,21 @@
 import createMiddleware from 'next-intl/middleware'
-import {locales, defaultLocale} from './src/i18n'
+import { NextRequest } from 'next/server'
+import { locales, defaultLocale } from './src/i18n'
 
-export default createMiddleware({
+const intlMiddleware = createMiddleware({
   locales,
-  defaultLocale
+  defaultLocale,
 })
 
+export default function middleware(request: NextRequest) {
+  const response = intlMiddleware(request)
+  response.headers.set(
+    'Cache-Control',
+    'public, max-age=3600, stale-while-revalidate=86400'
+  )
+  return response
+}
+
 export const config = {
-  matcher: ['/((?!_next|.*\\..*).*)']
+  matcher: ['/((?!_next|.*\\..*).*)'],
 }

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_APP_URL || 'https://maikekaisurf.com',
+  generateRobotsTxt: true,
+  sitemapSize: 7000,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "^0.263.1",
         "next": "15.5.0",
         "next-intl": "^3.26.5",
+        "next-seo": "^6.8.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "stripe": "^14.25.0",
@@ -30,6 +31,7 @@
         "autoprefixer": "^10.4.16",
         "eslint": "^8.56.0",
         "eslint-config-next": "15.5.0",
+        "next-sitemap": "^4.2.3",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.3.0",
         "typescript": "^5.3.0"
@@ -145,6 +147,13 @@
       "engines": {
         "node": ">=18.17.0"
       }
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
@@ -4943,6 +4952,52 @@
         "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/next-seo": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.8.0.tgz",
+      "integrity": "sha512-zcxaV67PFXCSf8e6SXxbxPaOTgc8St/esxfsYXfQXMM24UESUVSXFm7f2A9HMkAwa0Gqn4s64HxYZAGfdF4Vhg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "^8.1.1-canary.54 || >=9.0.0",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "set NODE_OPTIONS=--max-old-space-size=4096 && next build",
     "build:memory": "set NODE_OPTIONS=--max-old-space-size=8192 && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.31.5",
@@ -20,6 +21,7 @@
     "lucide-react": "^0.263.1",
     "next": "15.5.0",
     "next-intl": "^3.26.5",
+    "next-seo": "^6.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "stripe": "^14.25.0",
@@ -32,6 +34,7 @@
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
     "eslint-config-next": "15.5.0",
+    "next-sitemap": "^4.2.3",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.3.0"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://maikekaisurf.com
+
+# Sitemaps
+Sitemap: https://maikekaisurf.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</sitemapindex>

--- a/src/app/[locale]/accommodation/[slug]/page.tsx
+++ b/src/app/[locale]/accommodation/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getProductBySlug } from '@/features/catalog/services/products'
 import { notFound } from 'next/navigation'
+import { ProductSeo } from '@/features/catalog/components/ProductSeo'
 
 export const revalidate = 3600
 
@@ -13,6 +14,7 @@ export default async function AccommodationDetail({
 
   return (
     <section className="container mx-auto py-10">
+      <ProductSeo product={product} />
       <h1 className="text-3xl font-bold mb-4">{product.name}</h1>
       {product.longDescription && <p className="mb-4">{product.longDescription}</p>}
       {product.highlights.length > 0 && (

--- a/src/app/[locale]/combos/[slug]/page.tsx
+++ b/src/app/[locale]/combos/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getBundleBySlug } from '@/features/catalog/services/products'
 import { notFound } from 'next/navigation'
+import { ProductSeo } from '@/features/catalog/components/ProductSeo'
 
 export const revalidate = 3600
 
@@ -13,6 +14,7 @@ export default async function ComboDetail({
 
   return (
     <section className="container mx-auto py-10">
+      <ProductSeo product={bundle} />
       <h1 className="text-3xl font-bold mb-4">{bundle.name}</h1>
       {bundle.longDescription && <p className="mb-4">{bundle.longDescription}</p>}
       {bundle.highlights.length > 0 && (

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import '../globals.css'
 import { AuthProvider } from '@/features/auth'
 import { CartProvider } from '@/features/cart'
 import { PerformanceWidget } from '@/components/ui/PerformanceWidget'
+import { Seo } from '@/components/layout'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages } from 'next-intl/server'
 import { notFound } from 'next/navigation'
@@ -94,6 +95,7 @@ export default async function RootLayout({
           <link rel="manifest" href="/site.webmanifest" />
         </head>
         <body className={inter.className} suppressHydrationWarning={true}>
+          <Seo />
           <NextIntlClientProvider locale={locale} messages={messages}>
             <AuthProvider>
               <CartProvider>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,13 +1,19 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
 import { Hero } from '@/features/hero'
 import { BookingButtons } from '@/features/booking'
-import { Reviews } from '@/features/reviews'
 import { SurfPlans } from '@/features/surf-plans'
 import Header from '@/components/layout/Header'
 import Footer from '@/components/layout/Footer'
 import { ROUTES } from '@/lib/constants'
+
+const Reviews = dynamic(
+  () => import('@/features/reviews').then((m) => m.Reviews),
+  { suspense: true }
+)
 
 export default function Home() {
   const router = useRouter()
@@ -45,7 +51,9 @@ export default function Home() {
         <SurfPlans />
       </div>
       <div id="reseñas">
-        <Reviews />
+        <Suspense fallback={<p>Loading reviews...</p>}>
+          <Reviews />
+        </Suspense>
       </div>
       <div id="contacto">
         <Footer />

--- a/src/app/[locale]/plans/[slug]/page.tsx
+++ b/src/app/[locale]/plans/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getProductBySlug } from '@/features/catalog/services/products'
 import { notFound } from 'next/navigation'
+import { ProductSeo } from '@/features/catalog/components/ProductSeo'
 
 export const revalidate = 3600
 
@@ -13,6 +14,7 @@ export default async function PlanDetail({
 
   return (
     <section className="container mx-auto py-10">
+      <ProductSeo product={product} />
       <h1 className="text-3xl font-bold mb-4">{product.name}</h1>
       {product.longDescription && <p className="mb-4">{product.longDescription}</p>}
       {product.highlights.length > 0 && (

--- a/src/components/layout/Seo.tsx
+++ b/src/components/layout/Seo.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { DefaultSeo, OrganizationJsonLd } from 'next-seo'
+
+const url = process.env.NEXT_PUBLIC_APP_URL || 'https://maikekaisurf.com'
+
+export default function Seo() {
+  return (
+    <>
+      <DefaultSeo
+        titleTemplate="%s | Maikekai Surf"
+        defaultTitle="Maikekai Surf - Hotel y Escuela de Surf en Costa Rica"
+        description="Descubre Maikekai Surf, tu destino perfecto para aprender surf y hospedarte en Costa Rica."
+        canonical={url}
+        openGraph={{
+          url,
+          title: 'Maikekai Surf - Hotel y Escuela de Surf en Costa Rica',
+          description: 'Tu destino perfecto para aprender surf y hospedarte en Costa Rica',
+          siteName: 'Maikekai Surf',
+        }}
+        twitter={{
+          cardType: 'summary_large_image',
+        }}
+      />
+      <OrganizationJsonLd
+        useAppDir={true}
+        id={`${url}/#organization`}
+        url={url}
+        name="Maikekai Surf"
+        logo={`${url}/logo.png`}
+      />
+    </>
+  )
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from './Header'
 export { default as Footer } from './Footer'
 export { default as LanguageSwitcher } from './LanguageSwitcher'
+export { default as Seo } from './Seo'

--- a/src/features/catalog/components/ProductSeo.tsx
+++ b/src/features/catalog/components/ProductSeo.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { ProductJsonLd } from 'next-seo'
+import type { BaseProduct } from '@/types/catalog'
+
+interface Props {
+  product: BaseProduct
+}
+
+export function ProductSeo({ product }: Props) {
+  return (
+    <ProductJsonLd
+      useAppDir={true}
+      productName={product.name}
+      description={product.shortDescription || product.longDescription || ''}
+      offers={[
+        {
+          price: product.price / 100,
+          priceCurrency: product.currency,
+          availability: 'https://schema.org/InStock',
+        },
+      ]}
+    />
+  )
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,12 @@
+import { revalidateTag } from 'next/cache'
+
+export const PRODUCTS_TAG = 'products'
+export const AVAILABILITY_TAG = 'availability'
+
+export function revalidateProducts() {
+  revalidateTag(PRODUCTS_TAG)
+}
+
+export function revalidateAvailability() {
+  revalidateTag(AVAILABILITY_TAG)
+}


### PR DESCRIPTION
## Summary
- add next-seo default config with organization JSON-LD
- generate sitemap/robots and cache responses via middleware
- add product JSON-LD, dynamic reviews with Suspense and cache helpers

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af31ea68288330940eaeaa4e0d50dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Site-wide SEO defaults added, including Open Graph/Twitter metadata and Organization schema.
  - Product pages now include structured data for better search visibility.
  - Automatic sitemap generation and robots.txt added; sitemap served post-build.
- Refactor
  - Reviews section is now lazy-loaded with a loading state to improve perceived performance.
  - Added response caching headers and server-side data caching for faster page loads.
- Chores
  - Introduced SEO and sitemap tooling and a postbuild step to generate the sitemap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->